### PR TITLE
Initial clean-up of MD->RST conversion

### DIFF
--- a/source/guidelines/dg_protect-sensitive-data-in-files.rst
+++ b/source/guidelines/dg_protect-sensitive-data-in-files.rst
@@ -1,25 +1,20 @@
 Protect sensitive data in config files from disclosure
 ======================================================
 
-| It is preferable to avoid storing sensitive information in
-  configuration
-| files, but there are occasions where this is unavoidable. For those
-| situations, oslo.config provides a useful mechanism by which those
-| sensitive pieces of information can be sanitized and protected.
+It is preferable to avoid storing sensitive information in configuration files,
+but there are occasions where this is unavoidable. For those situations,
+oslo.config provides a useful mechanism by which those sensitive pieces of
+information can be sanitized and protected.
 
-| In order to trigger this santization, a 'secret=True' flag must be
-  added
-| to the 'cfg.StrOpt()' function when registering the oslo
-  configuration.
-| An example of this practice is provided below.
+In order to trigger this santization, a 'secret=True' flag must be added to the
+'cfg.StrOpt()' function when registering the oslo configuration.
+
+An example of this practice is provided below.
 
 Incorrect
 ~~~~~~~~~
 
-| In the example below the password 'secrets!' will be loaded through
-  the
-| cfg.StrOpt() function that could otherwise be logged and disclosed to
-| anyone with access to the log file (legitimate or not).
+In the example below the password 'secrets!' will be loaded through the cfg.StrOpt() function that could otherwise be logged and disclosed to anyone with access to the log file (legitimate or not).
 
 .. code:: python
 
@@ -40,11 +35,9 @@ A correct code example:
 Consequences
 ~~~~~~~~~~~~
 
-| If sensitive information is logged without being marked as secret,
-  that
-| sensitive information would be exposed whenever the logger debug flag
-  is
-| activated.
+If sensitive information is logged without being marked as secret, that
+sensitive information would be exposed whenever the logger debug flag is
+activated.
 
 Example Log Entries
 ~~~~~~~~~~~~~~~~~~~

--- a/source/guidelines/dg_rootwrap-recommendations-and-plans.rst
+++ b/source/guidelines/dg_rootwrap-recommendations-and-plans.rst
@@ -1,31 +1,27 @@
 Using Rootwrap in OpenStack
 ===========================
 
-| Most rootwrap filters are overly permissive, and allow running
-  commands
-| as root with no additional filtering on the arguments given, and
-  little
-| sanitization is done of the input commands.
+Most rootwrap filters are overly permissive, and allow running commands as root
+with no additional filtering on the arguments given, and little sanitization is
+done of the input commands.
 
-| Additionally, maintaining command filters is difficult. We found
-| existing filters that were no longer being used, and should have been
-| removed.
+Additionally, maintaining command filters is difficult. We found existing
+filters that were no longer being used, and should have been removed.
 
-| Finally, rootwrap cannot easily express precise semantics of the use
-| cases of privileged commands.
+Finally, rootwrap cannot easily express precise semantics of the use cases of
+privileged commands.
 
 To Privilege or Not to Privilege, That is the Question
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-| Before attempting to complete a privileged task with best practice,
-  the
-| task should be analyzed to see if the task can be completed in an
-| unprivileged fashion. For example, using service accounts with file
-| permissions and ownership for access instead of running a command as
-| root. Additionally, files can be owned by the project group instead of
-| the root group. These cases are preferred solutions where an
-| architectural change is preferred, and using privileged access can
-| introduce security issues.
+Before attempting to complete a privileged task with best practice, the task
+should be analyzed to see if the task can be completed in an unprivileged
+fashion. For example, using service accounts with file permissions and
+ownership for access instead of running a command as root.
+
+Additionally, files can be owned by the project group instead of the root
+group. These cases are  preferred solutions where an architectural change is
+preferred, and using privileged access can introduce security issues.
 
 Do the Necessary
 ~~~~~~~~~~~~~~~~
@@ -52,72 +48,62 @@ Instead, a better approach is multi-facted:
 -  Place minimum burden on developers while still creating better
    privilege separation
 
-| These guidelines will allow better semantic filtering of arguments
-  being
-| passed for each task. For example, if we need to mount an image or
-| device in a specific filesystem sub-tree the caller does not need to
-| pass the full path of the mount point. Additionally, each external
-| command or library will have its own interpretation of arguments, and
-  we
-| need to be able to sanitize those in task-specific and use-specific
-| ways.
+These guidelines will allow better semantic filtering of arguments being passed
+for each task. For example, if we need to mount an image or device in a
+specific filesystem sub-tree the caller does not need to pass the full path of
+the mount point. Additionally, each external command or library will have its
+own interpretation of arguments, and we need to be able to sanitize those in
+task-specific and use-specific ways.
 
-| Auditing the filtering and sanitization code is necessary as well, and
-| this needs to be easier to do so it can be done as needed. Sharing
-| common tasks will allow easier auditing as well as contribute to code
-| centralization and re-use.
+Auditing the filtering and sanitization code is necessary as well, and this
+needs to be easier to do so it can be done as needed. Sharing common tasks will
+allow easier auditing as well as contribute to code centralization and re-use.
 
 Looking Forward
 ~~~~~~~~~~~~~~~
 
-| Within the OpenStack project, understanding how to better limit the
-| usage of general commands is needed. For example, DeleteLink should
-  not
-| be able to delete an arbitrary path. Discussions are converging around
-  a
-| privileged daemon, similar to the one recently proposed for neutron.
-| This would give several advantages including better SELinux and
-| AppArmor profiles as the necessary privileges would be clearly stated
-  in
-| the code. Another area this would help is in system calls, both direct
-| and external. Unfortunately, this would seemingly contradict the last
-| bullet outlined above to build a better approach. It is, however,
-| necessary to secure the OpenStack project.
+Within the OpenStack project, understanding how to better limit the usage of
+general commands is needed. For example, DeleteLink should not be able to
+delete an arbitrary path. Discussions are converging around a privileged
+daemon, similar to the one recently proposed for neutron. This would give
+several advantages including better SELinux and AppArmor profiles as the
+necessary privileges would be clearly stated in the code. Another area this
+would help is in system calls, both direct and external. Unfortunately, this
+would seemingly contradict the last bullet outlined above to build a better
+approach. It is, however, necessary to secure the OpenStack project.
 
-| The alternative is to accept that projects (such as nova-compute) will
-| need to run as root, and as such will need to be fully audited -
-| including rootwrap filters. SELinux and AppArmor profiles will be the
-| responsibility of the deployer to create and maintain.
+The alternative is to accept that projects (such as nova-compute) will need to
+run as root, and as such will need to be fully audited - including rootwrap
+filters. SELinux and AppArmor profiles will be the responsibility of the
+deployer to create and maintain.
 
 Next Steps
 ~~~~~~~~~~
 
-| All calls to rootwrap, or project-specific interfaces to rootwrap,
-| should be migrated to interfaces in a project specific privileged task
-| module. This will still call rootwrap but will allow for better
-| sanitization, identification of what can be consolidated into shared
-| code, and will allow easier migration to a future solution.
+All calls to rootwrap, or project-specific interfaces to rootwrap, should be
+migrated to interfaces in a project specific privileged task module. This will
+still call rootwrap but will allow for better sanitization, identification of
+what can be consolidated into shared code, and will allow easier migration to a
+future solution.
 
-| The current codebase should be audited to determine if there are any
-| specific places that can be re-architected to avoid running tasks as
-| root. A Bandit plugin that looked for the use of rootwrap would allow
-| easy identification of the code that needs to be audited.
+The current codebase should be audited to determine if there are any specific
+places that can be re-architected to avoid running tasks as root. A Bandit
+plugin that looked for the use of rootwrap would allow easy identification of
+the code that needs to be audited.
 
-| Better documentation around how to write safe filters for rootwrap
-  would
-| allow for developers to become better educated, but would also give
-| reviewers a citeable document to link against in Gerrit.
+Better documentation around how to write safe filters for rootwrap would allow
+for developers to become better educated, but would also give reviewers a
+citable document to link against in Gerrit.
 
-| The neutron privilege separation daemon should be supported to
-| build experience and understand best practices around such an
-| implementation.
+The neutron privilege separation daemon should be supported to build experience
+and understand best practices around such an implementation.
 
-| Finally, when a final solution is determined the implementation should
-| be audited regularly to ensure it is being used correctly and the
-| results are as expected.
+Finally, when a final solution is determined the implementation should be
+audited regularly to ensure it is being used correctly and the results are as
+expected.
 
-References:
-~~~~~~~~~~~
+References
+~~~~~~~~~~
 
 -  `Original rootwrap discussion from the OpenStack developer
    mailinglist <http://lists.openstack.org/pipermail/openstack-dev/2015-February/055971.html>`__

--- a/source/guidelines/dg_strong-crypto.rst
+++ b/source/guidelines/dg_strong-crypto.rst
@@ -1,10 +1,9 @@
 Use Strong and Established Cryptographic Elements
 =================================================
 
-| Cryptography is a complex topic that is frequently misunderstood and
-  is
-| the area of significant debate. The specifics mentioned in this guide
-| are likely to change as state of the art continues to advance.
+Cryptography is a complex topic that is frequently misunderstood and is the
+area of significant debate. The specifics mentioned in this guide are likely to
+change as state of the art continues to advance.
 
 In general, you should follow some simple rules for using cryptography:
 
@@ -18,39 +17,38 @@ In general, you should follow some simple rules for using cryptography:
    generally a harder problem than algorithm selection and
    implementation.
 
-| Cryptography should be used to solve a specific problem or mitigate a
-| specific threat, such as ensuring the confidentiality of some data in
-| transit over an un-trusted network connection. Both the cryptographic
-| algorithm and the key strength should be appropriate for the threat
-  you
-| are trying to mitigate with the encryption, and the limitations of the
-| cryptography should be understood. For example, if encryption is
-| applied to a network link, it will not protect the data when it is
-| processed or stored at either end of that link. When deploying
-| cryptography, the impact to system performance and availability must
-| also be considered.
+Cryptography should be used to solve a specific problem or mitigate a specific
+threat, such as ensuring the confidentiality of some data in transit over an
+un-trusted network connection. Both the cryptographic algorithm and the key
+strength should be appropriate for the threat you are trying to mitigate with
+the encryption, and the limitations of the cryptography should be understood.
 
-| The Python cryptography libraries currently in OpenStack global
-| requirements include
-  `PyCrypto <https://www.dlitz.net/software/pycrypto/>`__,
-| `pyOpenSSL <https://github.com/pyca/pyopenssl>`__,
-| `cryptography <https://cryptography.io/>`__, and
-| `passlib <https://pythonhosted.org/passlib/>`__.
+For example, if encryption is applied to a network link, it will not protect
+the data when it is processed or stored at either end of that link. When
+deploying cryptography, the impact to system performance and availability must
+also be considered.
+
+The Python cryptography libraries currently in OpenStack global requirements
+include:
+
+-  `PyCrypto <https://www.dlitz.net/software/pycrypto/>`__,
+-  `pyOpenSSL <https://github.com/pyca/pyopenssl>`__,
+-  `cryptography <https://cryptography.io/>`__, and
+-  `passlib <https://pythonhosted.org/passlib/>`__.
 
 Use of the following cryptographic elements is encouraged:
 
 -  SHA-256 is the preferred hashing algorithm.
--  AES is the preferred general encryption algorithm, with 128, 192 or
-   256 bit key lengths.
--  HMAC is the preferred signing construction, in conjunction with a
-   preferred hashing algorithm.
--  TLSv1.2 or TLSv1.1 are preferred for protecting data in transit
-   between clients and web services, but they must be configured
-   securely,
-   certificate validity, expiry and revocation status must be checked.
+-  AES is the preferred general encryption algorithm, with 128, 192 or 256 bit
+   key lengths.
+-  HMAC is the preferred signing construction, in conjunction with a preferred
+   hashing algorithm.
+-  TLSv1.2 or TLSv1.1 are preferred for protecting data in transit between
+   clients and web services, but they must be configured securely, certificate
+   validity, expiry and revocation status must be checked.
 
-| While for some use cases it may seem appropriate to use a weaker
-| cryptographic element, the options listed above are generally advised.
+While for some use cases it may seem appropriate to use a weaker cryptographic
+element, the options listed above are generally advised.
 
 Usage of the following is strongly discouraged:
 
@@ -62,9 +60,9 @@ Usage of the following is strongly discouraged:
 Consequences
 ~~~~~~~~~~~~
 
-| Weak cryptographic elements may be vulnerable to various types of
-| attack, ultimately affecting confidentiality and integrity of the
-| associated system or dataset at risk.
+Weak cryptographic elements may be vulnerable to various types of attack,
+ultimately affecting confidentiality and integrity of the associated system or
+dataset at risk.
 
 References
 ~~~~~~~~~~

--- a/source/guidelines/dg_use-oslo-rootwrap-securely.rst
+++ b/source/guidelines/dg_use-oslo-rootwrap-securely.rst
@@ -1,17 +1,14 @@
 Use oslo rootwrap securely
 ==========================
 
-| Rootwrap provides a mechanism in which a caller may execute a command
-| line with escalated privileges (typically as root). Special care must
-| be taken to ensure this use of code does not permit a lesser
-  privileged
-| user to run commands as root.
+Rootwrap provides a mechanism in which a caller may execute a command line with
+escalated privileges (typically as root). Special care must be taken to ensure
+this use of code does not permit a lesser privileged user to run commands as
+root.
 
-| Rootwrap provides a series of filters to restrict command usage to
-  limit
-| the exposure. The most commonly used filter is CommandFilter, but it
-| also provides the least amount of restriction on how the command is
-| called.
+Rootwrap provides a series of filters to restrict command usage to limit the
+exposure. The most commonly used filter is CommandFilter, but it also provides
+the least amount of restriction on how the command is called.
 
 Consider the following before using rootwrap:
 
@@ -33,9 +30,8 @@ And example of insecure usage:
     # nova/virt/disk/vfs/localfs.py: 'chmod'
     chmod: CommandFilter, chmod, root
 
-| This filter is too permissive because it allows the chmod command to
-  be
-| run as root with any number of arguments, on any file.
+This filter is too permissive because it allows the chmod command to be run as
+root with any number of arguments, on any file.
 
 Correct
 ~~~~~~~
@@ -51,9 +47,8 @@ An example of more secure usage:
 Consequences
 ~~~~~~~~~~~~
 
--  A user of the API could potentially inject input that might be
-   executed at high privileges due to an in-effective rootwrap
-   configuration.
+-  A user of the API could potentially inject input that might be executed at
+   high privileges due to an in-effective rootwrap configuration.
 
 References
 ~~~~~~~~~~

--- a/source/guidelines/dg_use-subprocess-securely.rst
+++ b/source/guidelines/dg_use-subprocess-securely.rst
@@ -1,16 +1,13 @@
 Subprocess Shell Injection
 ==========================
 
-| Many common tasks involve interacting with the operating system - we
-| write a lot of code that configures, modifies, or otherwise controls
-  the
-| system, and there are a number of pitfalls that can come along with
-| that.
+Many common tasks involve interacting with the operating system - we write a
+lot of code that configures, modifies, or otherwise controls the system, and
+there are a number of pitfalls that can come along with that.
 
-| Shelling out to another program is a pretty common thing to want to
-  do.
-| In most cases, you will want to pass parameters to this other program.
-| Here is a simple function for pinging another server.
+Shelling out to another program is a pretty common thing to want to do. In most
+cases, you will want to pass parameters to this other program. Here is a simple
+function for pinging another server.
 
 Incorrect
 ~~~~~~~~~
@@ -23,13 +20,13 @@ Incorrect
     >>> ping('8.8.8.8')
     64 bytes from 8.8.8.8: icmp_seq=1 ttl=58 time=5.82 ms
 
-| This program just supplies a string as a command to the shell, which
-| runs it without thinking too hard about it. There's no semantic
-| separation between the input parameters, i.e. the shell cannot tell
-| where the command is supposed to end, and where the parameters start.
+This program just supplies a string as a command to the shell, which runs it
+without thinking too hard about it. There's no semantic separation between the
+input parameters, i.e. the shell cannot tell where the command is supposed to
+end, and where the parameters start.
 
-| If the ``myserver`` parameter is user controlled, this can be used to
-| execute arbitary programs, such as rm:
+If the ``myserver`` parameter is user controlled, this can be used to execute
+arbitrary programs, such as rm:
 
 .. code:: python
 
@@ -42,8 +39,8 @@ Incorrect
     rm: cannot remove `/bin/cgroups-umount': Permission denied
     ...
 
-| If you choose to test this, we recommend that you pick a command that
-| is less destructive than 'rm -rf /', such as 'touch helloworld.txt'.
+If you choose to test this, we recommend that you pick a command that is less
+destructive than 'rm -rf /', such as 'touch helloworld.txt'.
 
 Correct
 ~~~~~~~
@@ -56,25 +53,22 @@ This function can be re-written safely:
         args = ['ping', '-c', '1', myserver]
         return subprocess.check_output(args, shell=False)
 
-| Rather than passing a string to subprocess, our function passes a list
-| of strings. The ping program gets each argument separately (even if
-  the
-| argument has a space in it), so the shell does not process other
-| commands that are provided by the user after the ping command
-| terminates. You do not have to explicitly set shell=False - it is the
-| default.
+Rather than passing a string to subprocess, our function passes a list of
+strings. The ping program gets each argument separately (even if the argument
+has a space in it), so the shell does not process other commands that are
+provided by the user after the ping command terminates. You do not have to
+explicitly set shell=False - it is the default.
 
-| If we test this with the same input as before, the ping command
-| interprets the ``myserver`` value correctly as a single argument, and
-| complains because that is a really weird hostname to try and ping.
+If we test this with the same input as before, the ping command interprets the
+``myserver`` value correctly as a single argument, and complains because that
+is a really weird hostname to try and ping.
 
 .. code:: python
 
     >>> ping('8.8.8.8; rm -rf /')
     ping: unknown host 8.8.8.8; rm -rf /
 
-| This program is now much safer, even if it has to allow user-provided
-| input.
+This program is now much safer, even if it has to allow user-provided input.
 
 Consequences
 ~~~~~~~~~~~~

--- a/source/guidelines/dg_using-file-paths.rst
+++ b/source/guidelines/dg_using-file-paths.rst
@@ -1,23 +1,19 @@
 Path Traversal
 ==============
 
-| Often we will refer to a file on disk or other resource using a path.
-  A
-| path traversal attack is when an attacker supplies input that gets
-  used
-| with our path to access a file on the file system that we did not
-| intend. The input usually attempts to break out of the application's
-| working directory and access a file elsewhere on the file system. This
-| category of attack can be mitigated by restricting the scope of file
-| system access and reducing attack surface by using a restricted file
-| permission profile.
+Often we will refer to a file on disk or other resource using a path. A path
+traversal attack is when an attacker supplies input that gets used with our
+path to access a file on the file system that we did not intend. The input
+usually attempts to break out of the application's working directory and access
+a file elsewhere on the file system. This category of attack can be mitigated
+by restricting the scope of file system access and reducing attack surface by
+using a restricted file permission profile.
 
 Incorrect
 ~~~~~~~~~
 
-| A typical remote vector for path traversal in web applications might
-| involve serving or storing files on the file system. Consider the
-| following example:
+A typical remote vector for path traversal in web applications might involve
+serving or storing files on the file system. Consider the following example:
 
 .. code:: python
 
@@ -38,21 +34,19 @@ Incorrect
     if __name__ == '__main__':
         app.run(debug=True)
 
-| As the attacker controls the input that is used directly in
-  constructing
-| a path they are able to access any file on the system. For example
-| consider what happens if an attacker makes a request like:
+As the attacker controls the input that is used directly in constructing a path
+they are able to access any file on the system. For example consider what
+happens if an attacker makes a request like:
 
 ::
 
     curl http://example.com/?image_name=../../../../../../../../etc/passwd
 
-| Path traversal flaws also can happen when unpacking a compressed
-  archive
-| of files. An example of where this has happened within OpenStack is
-| `OSSA-2011-001 <http://security.openstack.org/ossa/OSSA-2011-001.html>`__.
-| In this case a tar file from an untrusted source could be unpacked to
-| overwrite files on the host operating system.
+Path traversal flaws also can happen when unpacking a compressed archive of
+files. An example of where this has happened within OpenStack is
+`OSSA-2011-001 <http://security.openstack.org/ossa/OSSA-2011-001.html>`__. In
+this case a tar file from an untrusted source could be unpacked to overwrite
+files on the host operating system.
 
 .. code:: python
 
@@ -69,9 +63,9 @@ Incorrect
 Correct
 ~~~~~~~
 
-| The following example demonstrates how you can use python code to
-| restrict access to files within a specific directory. This can be used
-| as a mechanism to defeat path traversal.
+The following example demonstrates how you can use python code to restrict
+access to files within a specific directory. This can be used as a mechanism to
+defeat path traversal.
 
 .. code:: python
 
@@ -96,11 +90,10 @@ Correct
     if __name__ == "__main__":
         main(sys.argv[1:])
 
-| Another approach to restricting file system access to maintain an
-| indirect mapping between a unique identifier and a file path that
-  exists
-| on the operating system. This prevents users supplying malicious input
-| to access unintended files.
+Another approach to restricting file system access to maintain an indirect
+mapping between a unique identifier and a file path that exists on the
+operating system. This prevents users supplying malicious input to access
+unintended files.
 
 .. code:: python
 
@@ -117,10 +110,9 @@ Correct
 Consequences
 ~~~~~~~~~~~~
 
-| Not validating file paths allows the attacker to read or write to any
-| file that the application has access to. This can lead to information
-| leakage and can be used to pivot to other more serious attacks like
-| remote code execution.
+Not validating file paths allows the attacker to read or write to any file
+that the application has access to. This can lead to information leakage and
+can be used to pivot to other more serious attacks like remote code execution.
 
 -  `OSSA-2011-001 <http://security.openstack.org/ossa/OSSA-2011-001.html>`__
 -  `OSSA-2014-041 <http://security.openstack.org/ossa/OSSA-2014-041.html>`__

--- a/source/guidelines/dg_using-temporary-files-securely.rst
+++ b/source/guidelines/dg_using-temporary-files-securely.rst
@@ -1,66 +1,55 @@
 Create, use, and remove temporary files securely
 ================================================
 
-| Often we want to create temporary files to save data that we can't
-  hold
-| in memory or to pass to external programs that must read from a file.
-| The obvious way to do this is to generate a unique file name in a
-  common
-| system temporary directory such as /tmp, but doing so correctly is
-  harder
-| than it seems. Safely creating a temporary file or directory means
-  following
-| a number of rules (see the references for more details). We should
-  never do
-| this ourselves but use the correct existing library function. We also
-| must take care to cleanup our temporary files even in the face of
-  errors.
+Often we want to create temporary files to save data that we can't hold in
+memory or to pass to external programs that must read from a file. The obvious
+way to do this is to generate a unique file name in a common system temporary
+directory such as /tmp, but doing so correctly is harder than it seems. Safely
+creating a temporary file or directory means following a number of rules (see
+the references for more details). We should never do this ourselves but use the
+correct existing library function. We also must take care to cleanup our
+temporary files even in the face of errors.
 
-| If we don't take all these precautions we open ourselves up to a
-  number
-| of dangerous security problems. Malicious users that can predict the
-| file name and write to directory containing the temporary file can
-| effectively hijack the temporary file by creating a symlink with the
-| name of the temporary file before the program creates the file itself.
-| This allows a malicious user to supply malicious data or cause actions
-| by the program to affect attacker chosen files. The references
-| have more extensive descriptions of potential dangers.
+If we don't take all these precautions we open ourselves up to a number of
+dangerous security problems. Malicious users that can predict the file name and
+write to directory containing the temporary file can effectively hijack the
+temporary file by creating a symlink with the name of the temporary file before
+the program creates the file itself. This allows a malicious user to supply
+malicious data or cause actions by the program to affect attacker chosen files.
+The references have more extensive descriptions of potential dangers.
 
-| Most programming lanuages provide functions to create temporary
-| files. However, some of these functions are unsafe and should not
-| be used. We need to be careful to use the safe functions.
+Most programming lanuages provide functions to create temporary files. However,
+some of these functions are unsafe and should not be used. We need to be
+careful to use the safe functions.
 
-| Despite the safer temporary file creation APIs we must still be
-| aware of where we are creating tempory files. Generally, temporary
-| files should always be created on the local filesystem. Many
-| remote filesystems (for example, NFSv2) do not support the open
-| flags needed to safely create tempoary files.
+Despite the safer temporary file creation APIs we must still be aware of where
+we are creating tempory files. Generally, temporary files should always be
+created on the local filesystem. Many remote filesystems (for example, NFSv2)
+do not support the open flags needed to safely create temporary files.
 
 Python
 ~~~~~~
 
-| Use \| Avoid
-| ----- \| -----
-| tempfile.TemporaryFile \| tempfile.mktemp
-| tempfile.NamedTemporaryFile \| open
-| tempfile.SpooledTemporaryFile \|
-| tempfile.mkstemp \|
-| tempfile.mkdtemp \|
+=========================== ===============
+Use                         Avoid
+=========================== ===============
+tempfile.TemporaryFile      tempfile.mktemp
+tempfile.NamedTemporaryFile open
+tempfile.SpoolTemporaryFile
+tempfile.mkstemp
+tempfile.mkdtemp
+=========================== ===============
 
-| tempfile.TemporaryFile should be used whenever possible. Besides
-| creating temporary files safely it also hides the file and cleans up
-  the
-| file automatically.
+tempfile.TemporaryFile should be used whenever possible. Besides creating
+temporary files safely it also hides the file and cleans up the file
+automatically.
 
 Incorrect
 ~~~~~~~~~
 
-| Creating temporary files with predictable paths leaves them open to
-  time
-| of check, time of use attacks (TOCTOU). Given the following code
-  snippet
-| an attacker might pre-emptively place a file at the specified
-  location.
+Creating temporary files with predictable paths leaves them open to time of
+check, time of use attacks (TOCTOU). Given the following code snippet an
+attacker might pre-emptively place a file at the specified location.
 
 .. code:: python
 
@@ -73,9 +62,8 @@ Incorrect
         with open(tmp, "w") file:
             file.write("defaults")
 
-| There is also an insecure method within the Python standard library
-  that
-| cannot be used in a secure way to create temporary file creation.
+There is also an insecure method within the Python standard library that cannot
+be used in a secure way to create temporary file creation.
 
 .. code:: python
 
@@ -84,8 +72,8 @@ Incorrect
 
     open(tempfile.mktemp(), "w")
 
-| Finally there are many ways we could try to create a secure filename
-| that will not be secure and is easily predictable.
+Finally there are many ways we could try to create a secure filename that will
+not be secure and is easily predictable.
 
 .. code:: python
 
@@ -96,9 +84,9 @@ Incorrect
 Correct
 ~~~~~~~
 
-| The Python standard library provides a number of secure ways to create
-| temporary files and directories. The following are examples of how you
-| can use them.
+The Python standard library provides a number of secure ways to create
+temporary files and directories. The following are examples of how you can use
+them.
 
 Creating files:
 
@@ -131,12 +119,9 @@ Creating files:
     finally:
         os.remove(path)
 
-| We can also safely create a temporary directory and create temporary
-  files
-| inside it. We need to set the umask before creating the
-| file to ensure the permissions on the file only allow the creator read
-  and
-| write access.
+We can also safely create a temporary directory and create temporary files
+inside it. We need to set the umask before creating the file to ensure the
+permissions on the file only allow the creator read and write access.
 
 .. code:: python
 

--- a/source/guidelines/dg_validate-certificates.rst
+++ b/source/guidelines/dg_validate-certificates.rst
@@ -1,15 +1,13 @@
 Validate certificates on HTTPS connections to avoid man-in-the-middle attacks
 =============================================================================
 
-| When developing a module that makes secure HTTPS connections to use a
-| library verifies certificates. Many such libraries also provide an
-| option to ignore certificate verification failures. These options
-| should be exposed to the OpenStack deployer to choose their level of
-| risk.
+When developing a module that makes secure HTTPS connections to use a library
+verifies certificates. Many such libraries also provide an option to ignore
+certificate verification failures. These options should be exposed to the
+OpenStack deployer to choose their level of risk.
 
-| Although the title of this guideline calls out HTTPS, verifying the
-| identity of the hosts you are connecting to applies to most protocols
-| (SSH, LDAPS, etc).
+Although the title of this guideline calls out HTTPS, verifying the identity of
+the hosts you are connecting to applies to most protocols (SSH, LDAPS, etc).
 
 Incorrect
 ~~~~~~~~~
@@ -19,9 +17,8 @@ Incorrect
     import requests
     requests.get('https://www.openstack.org/', verify=False)
 
-| The example above uses verify=False to bypass the check the
-  certificate
-| received against those in the CA trust store.
+The example above uses verify=False to bypass the check the certificate
+received against those in the CA trust store.
 
 Correct
 ~~~~~~~
@@ -31,18 +28,17 @@ Correct
     import requests
     requests.get('https://www.openstack.org/', verify=CONF.ca_file)
 
-| The example above uses the variable CONF.ca\_file to store the
-  location of
-| the CA trust store, which is used to confirm that the certificate
-| received is from a trusted authority.
+The example above uses the variable CONF.ca\_file to store the location of the
+CA trust store, which is used to confirm that the certificate received is from
+a trusted authority.
 
 Consequences
 ~~~~~~~~~~~~
 
-| A main-in-the-middle (MITM) attack can allow a party to monitor, copy,
-| and manipulate all data transferred between the parties. The impact of
-| this depends on what data is sent. Comcast satisfaction survey data
-| will be less valuable than banking passwords and account information.
+A main-in-the-middle (MITM) attack can allow a party to monitor, copy, and
+manipulate all data transferred between the parties. The impact of this depends
+on what data is sent. Comcast satisfaction survey data will be less valuable
+than banking passwords and account information.
 
 -  `OSSA-2014-005 <http://security.openstack.org/ossa/OSSA-2014-005.html>`__
 


### PR DESCRIPTION
This commit cleans up some issues with paragraphs and tables in
half of the secure development guidance notes.  These were
genereated by a script which converted MD->RST, which mostly
worked but missed a few things.